### PR TITLE
Update to latest netket 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 GPSKet.egg-info
+
+# Developer files #
+###################
+.envrc

--- a/GPSKet/driver/minSR.py
+++ b/GPSKet/driver/minSR.py
@@ -12,8 +12,6 @@ from netket.utils import mpi
 
 from GPSKet.vqs import MCStateUniqueSamples
 
-from netket.optimizer.qgt.qgt_jacobian_common import choose_jacobian_mode
-
 class minSRVMC(VMC):
     """
     VMC driver utilizing the minSR updates as proposed in https://arxiv.org/abs/2302.01941
@@ -24,7 +22,7 @@ class minSRVMC(VMC):
         assert(not (mode is not None and holomorphic is not None))
         assert (diag_shift >= 0.) and (diag_shift <= 1.)
         if mode is None:
-            self.mode = choose_jacobian_mode(self.state._apply_fun, self.state.parameters,
+            self.mode = nk.jax.jacobian_default_mode(self.state._apply_fun, self.state.parameters,
                                              self.state.model_state, self.state.samples,
                                              holomorphic=holomorphic)
         else:

--- a/GPSKet/optimizer/qgt/qgt_jacobian_dense_rmsprop.py
+++ b/GPSKet/optimizer/qgt/qgt_jacobian_dense_rmsprop.py
@@ -9,7 +9,6 @@ from netket.utils.types import PyTree, Scalar
 from netket.optimizer import LinearOperator
 from netket.optimizer.linear_operator import Uninitialized
 from netket.optimizer.qgt.common import check_valid_vector_type
-from netket.optimizer.qgt.qgt_jacobian_common import choose_jacobian_mode
 
 from GPSKet.vqs import MCStateUniqueSamples
 
@@ -48,7 +47,7 @@ def QGTJacobianDenseRMSProp(
         pdf = None
 
     if mode is None:
-        mode = choose_jacobian_mode(
+        mode = nkjax.jacobian_default_mode(
             vstate._apply_fun,
             vstate.parameters,
             vstate.model_state,

--- a/GPSKet/optimizer/qgt/qgt_jacobian_dense_unique_samples.py
+++ b/GPSKet/optimizer/qgt/qgt_jacobian_dense_unique_samples.py
@@ -1,5 +1,5 @@
 import netket as nk
-from netket.optimizer.qgt.qgt_jacobian_common import (choose_jacobian_mode, sanitize_diag_shift, to_shift_offset, rescale)
+from netket.optimizer.qgt.qgt_jacobian_common import (sanitize_diag_shift, to_shift_offset, rescale)
 from netket.optimizer.qgt.qgt_jacobian_dense import QGTJacobianDenseT
 
 import netket.jax as nkjax
@@ -30,7 +30,7 @@ def QGTJacobianDenseUniqueSamples(vstate=None, *, mode: str = None, holomorphic:
         return partial(QGTJacobianDenseUniqueSamples, mode=mode, holomorphic=holomorphic)
 
     if mode is None:
-        mode = choose_jacobian_mode(vstate._apply_fun, vstate.parameters, vstate.model_state, vstate.samples[0], holomorphic=holomorphic)
+        mode = nkjax.jacobian_default_mode(vstate._apply_fun, vstate.parameters, vstate.model_state, vstate.samples[0], holomorphic=holomorphic)
     else:
         assert(holomorphic is None)
 


### PR DESCRIPTION
The latest release of netket moves around `chose_jacobian_mode` to a more stable position.
This updates it to the new usage.

(Please double check that this works! )