### PR TITLE
Move to pyproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-netket_fidelity/_version.py
+GPSKet/_version.py
 .Python
 build/
 develop-eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,133 @@
-*.pyc
-GPSKet.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# Developer files #
-###################
+# C extensions
+*.so
+
+# Distribution / packaging
+netket_fidelity/_version.py
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 .envrc
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+.virtual_ocuments
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+.DS_Store
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,83 @@
+[build-system]
+requires = ["hatchling>=1.8.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "GPSKet"
+description="GPS plugin for NetKet introducing new models, optimizers and Fermionic functionality."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "netket~=3.9",
+]
+authors=[
+    {name = "Yannick Rath"},
+    {name = "Massimo Bortone"},
+]
+version = "0.0.1"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6",
+    "pytest-cov>=2.10.1",
+    "black==23.7.0",
+    "ruff==0.0.287",
+]
+
+[tool.hatch.build]
+include = ["GPSKet*"]
+
+# Development tools
+
+[tool.black]
+line-length = 88
+target-version = ['py39', 'py310', 'py311']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.coverage.run]
+branch = true
+parallel = true
+command_line = "-m pytest --verbose tests"
+source = ["tests"]
+
+[tool.pytest.ini_options]
+addopts = "--color=yes --verbose --durations=100 --tb=short"
+doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER"
+filterwarnings = [
+    "ignore::UserWarning",
+    "ignore:No GPU/TPU found, falling back to CPU.:UserWarning",
+    "ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning",
+    "ignore:`np.long`",
+    "ignore:`np.int` is a deprecated alias for the builtin `int`",
+    "ignore::DeprecationWarning:tensorboardX",
+]
+testpaths = [
+    "tests",
+]
+
+[tool.ruff]
+target-version = "py39"
+select = ["E", "F", "W"]
+fixable = ["E", "F", "W"]
+ignore = ["E501", "E731", "E741"]
+#ignore = ["E266"]
+line-length = 88
+exclude = ["Examples/Legacy"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402","F401"]
+"tutorials" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="GPS plugin for NetKet introducing new models, optimizers and Fermio
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "netket~=3.9",
+    "netket>3.5",
 ]
 authors=[
     {name = "Yannick Rath"},

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from distutils.core import setup
-
-setup(name="GPSKet", packages=["GPSKet"])


### PR DESCRIPTION
You might not know it, but `setup.py` is deprecated and will eventually stop working. 
The way to setup packages is supposed to be a `pyproject` file that lists dependencies, in particular minimum versions, and you install the package with `pip install .` or `pip install -e .` to make it editable.

This is useful also because you can directly install from GitHub `pip install git+https://github.com/BoothGroup/GPSKet` and includes definitions to run tests automatically with only `pytest`. 

I guessed the minimum python version. You might want to edit this.